### PR TITLE
Add editable wrappers and preview mode

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,9 @@
 
-import React from 'react';
-import { Link } from 'react-router-dom';
-import { Mail, Globe, MapPin } from 'lucide-react';
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { Mail, Globe } from 'lucide-react'
+import EditableText from './editable/EditableText'
+import EditableImage from './editable/EditableImage'
 
 const Footer = () => {
   return (
@@ -12,67 +14,161 @@ const Footer = () => {
           <div className="col-span-1 lg:col-span-2">
             <div className="flex items-center space-x-3 mb-4">
               <div className="w-10 h-10 bg-white rounded-lg flex items-center justify-center">
-                <img 
-                  src="/lovable-uploads/9fe4bf5c-153e-4db8-a758-19dbd5b2bf54.png" 
-                  alt="CCEA Logo" 
+                <EditableImage
+                  src="/lovable-uploads/9fe4bf5c-153e-4db8-a758-19dbd5b2bf54.png"
+                  alt="CCEA Logo"
                   className="w-8 h-8"
+                  fieldPath="logo"
+                  objectId="footer"
                 />
               </div>
               <div>
-                <span className="text-xl font-semibold">CCEA</span>
-                <p className="text-sm text-gray-300">Civic and Citizenship Education Alliance</p>
+                <EditableText
+                  text="CCEA"
+                  as="span"
+                  className="text-xl font-semibold"
+                  fieldPath="title"
+                  objectId="footer"
+                />
+                <EditableText
+                  text="Civic and Citizenship Education Alliance"
+                  as="p"
+                  className="text-sm text-gray-300"
+                  fieldPath="subtitle"
+                  objectId="footer"
+                />
               </div>
             </div>
-            <p className="text-gray-300 mb-4 max-w-md">
-              Join a global network of K-12 schools, universities, and organizations committed to 
-              transforming civic and citizenship education across diverse local and national contexts.
-            </p>
+            <EditableText
+              text="Join a global network of K-12 schools, universities, and organizations committed to transforming civic and citizenship education across diverse local and national contexts."
+              className="text-gray-300 mb-4 max-w-md"
+              fieldPath="description"
+              objectId="footer"
+            />
             <div className="flex items-center space-x-4 text-sm text-gray-300">
               <div className="flex items-center">
                 <Globe className="h-4 w-4 mr-2" />
-                <span>Global Network</span>
+                <EditableText
+                  text="Global Network"
+                  as="span"
+                  fieldPath="globalNetwork"
+                  objectId="footer"
+                />
               </div>
               <div className="flex items-center">
                 <Mail className="h-4 w-4 mr-2" />
-                <span>contact@ccea.org</span>
+                <EditableText
+                  text="contact@ccea.org"
+                  as="span"
+                  fieldPath="email"
+                  objectId="footer"
+                />
               </div>
             </div>
           </div>
 
           {/* Quick Links */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">Quick Links</h3>
+            <EditableText
+              text="Quick Links"
+              as="h3"
+              className="text-lg font-semibold mb-4"
+              fieldPath="quickLinks.title"
+              objectId="footer"
+            />
             <ul className="space-y-2">
-              <li><Link to="/about" className="text-gray-300 hover:text-white transition-colors">About Us</Link></li>
-              <li><Link to="/membership" className="text-gray-300 hover:text-white transition-colors">Membership</Link></li>
-              <li><Link to="/articles" className="text-gray-300 hover:text-white transition-colors">Articles</Link></li>
-              <li><Link to="/resources" className="text-gray-300 hover:text-white transition-colors">Resources</Link></li>
-              <li><Link to="/events" className="text-gray-300 hover:text-white transition-colors">Events</Link></li>
-              <li><Link to="/members" className="text-gray-300 hover:text-white transition-colors">Members</Link></li>
+              <li>
+                <Link to="/about" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="About Us" as="span" fieldPath="quickLinks.about" objectId="footer" />
+                </Link>
+              </li>
+              <li>
+                <Link to="/membership" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="Membership" as="span" fieldPath="quickLinks.membership" objectId="footer" />
+                </Link>
+              </li>
+              <li>
+                <Link to="/articles" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="Articles" as="span" fieldPath="quickLinks.articles" objectId="footer" />
+                </Link>
+              </li>
+              <li>
+                <Link to="/resources" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="Resources" as="span" fieldPath="quickLinks.resources" objectId="footer" />
+                </Link>
+              </li>
+              <li>
+                <Link to="/events" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="Events" as="span" fieldPath="quickLinks.events" objectId="footer" />
+                </Link>
+              </li>
+              <li>
+                <Link to="/members" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="Members" as="span" fieldPath="quickLinks.members" objectId="footer" />
+                </Link>
+              </li>
             </ul>
           </div>
 
           {/* Organization */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">Organization</h3>
+            <EditableText
+              text="Organization"
+              as="h3"
+              className="text-lg font-semibold mb-4"
+              fieldPath="organization.title"
+              objectId="footer"
+            />
             <ul className="space-y-2">
-              <li><Link to="/team" className="text-gray-300 hover:text-white transition-colors">Our Team</Link></li>
-              <li><Link to="/governance" className="text-gray-300 hover:text-white transition-colors">Governance</Link></li>
-              <li><Link to="/governance-charter" className="text-gray-300 hover:text-white transition-colors">Governance Charter</Link></li>
-              <li><Link to="/brand-guidelines" className="text-gray-300 hover:text-white transition-colors">Brand Guidelines</Link></li>
-              <li><Link to="/contact" className="text-gray-300 hover:text-white transition-colors">Contact</Link></li>
-              <li><Link to="/impressum" className="text-gray-300 hover:text-white transition-colors">Impressum</Link></li>
+              <li>
+                <Link to="/team" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="Our Team" as="span" fieldPath="organization.team" objectId="footer" />
+                </Link>
+              </li>
+              <li>
+                <Link to="/governance" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="Governance" as="span" fieldPath="organization.governance" objectId="footer" />
+                </Link>
+              </li>
+              <li>
+                <Link to="/governance-charter" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="Governance Charter" as="span" fieldPath="organization.charter" objectId="footer" />
+                </Link>
+              </li>
+              <li>
+                <Link to="/brand-guidelines" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="Brand Guidelines" as="span" fieldPath="organization.brandGuidelines" objectId="footer" />
+                </Link>
+              </li>
+              <li>
+                <Link to="/contact" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="Contact" as="span" fieldPath="organization.contact" objectId="footer" />
+                </Link>
+              </li>
+              <li>
+                <Link to="/impressum" className="text-gray-300 hover:text-white transition-colors">
+                  <EditableText text="Impressum" as="span" fieldPath="organization.impressum" objectId="footer" />
+                </Link>
+              </li>
             </ul>
           </div>
         </div>
 
         <div className="border-t border-gray-800 mt-8 pt-8 flex flex-col md:flex-row justify-between items-center">
-          <p className="text-gray-400 text-sm">
-            © 2024 Civic and Citizenship Education Alliance. All rights reserved.
-          </p>
-          <p className="text-gray-400 text-sm mt-4 md:mt-0">
-            An initiative of the <b>Global Citizenship Foundation</b>.
-          </p>
+          <EditableText
+            text="© 2024 Civic and Citizenship Education Alliance. All rights reserved."
+            as="p"
+            className="text-gray-400 text-sm"
+            fieldPath="copyright"
+            objectId="footer"
+          />
+          <EditableText
+            text="An initiative of the <b>Global Citizenship Foundation</b>."
+            as="p"
+            className="text-gray-400 text-sm mt-4 md:mt-0"
+            fieldPath="initiative"
+            objectId="footer"
+          />
         </div>
       </div>
     </footer>

--- a/src/components/editable/EditableImage.tsx
+++ b/src/components/editable/EditableImage.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react'
+import usePreviewMode from '@/hooks/usePreviewMode'
 
 interface EditableImageProps {
   src: string
@@ -20,14 +21,17 @@ const EditableImage: React.FC<EditableImageProps> = ({
   width,
   height 
 }) => {
+  const isPreview = usePreviewMode()
   const editableProps: Record<string, any> = {}
-  
-  if (fieldPath) {
-    editableProps['data-sb-field-path'] = fieldPath
-  }
-  
-  if (objectId) {
-    editableProps['data-sb-object-id'] = objectId
+
+  if (isPreview) {
+    if (fieldPath) {
+      editableProps['data-sb-field-path'] = fieldPath
+    }
+
+    if (objectId) {
+      editableProps['data-sb-object-id'] = objectId
+    }
   }
 
   return (

--- a/src/components/editable/EditableText.tsx
+++ b/src/components/editable/EditableText.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react'
+import usePreviewMode from '@/hooks/usePreviewMode'
 
 interface EditableTextProps {
   text: string
@@ -16,14 +17,17 @@ const EditableText: React.FC<EditableTextProps> = ({
   as: Component = 'p', 
   className = '' 
 }) => {
+  const isPreview = usePreviewMode()
   const editableProps: Record<string, any> = {}
-  
-  if (fieldPath) {
-    editableProps['data-sb-field-path'] = fieldPath
-  }
-  
-  if (objectId) {
-    editableProps['data-sb-object-id'] = objectId
+
+  if (isPreview) {
+    if (fieldPath) {
+      editableProps['data-sb-field-path'] = fieldPath
+    }
+
+    if (objectId) {
+      editableProps['data-sb-object-id'] = objectId
+    }
   }
 
   return (

--- a/src/components/editable/EditableWrapper.tsx
+++ b/src/components/editable/EditableWrapper.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react'
+import usePreviewMode from '@/hooks/usePreviewMode'
 
 interface EditableWrapperProps {
   children: React.ReactNode
@@ -16,14 +17,17 @@ const EditableWrapper: React.FC<EditableWrapperProps> = ({
   className = '',
   as: Component = 'div' 
 }) => {
+  const isPreview = usePreviewMode()
   const editableProps: Record<string, any> = {}
-  
-  if (fieldPath) {
-    editableProps['data-sb-field-path'] = fieldPath
-  }
-  
-  if (objectId) {
-    editableProps['data-sb-object-id'] = objectId
+
+  if (isPreview) {
+    if (fieldPath) {
+      editableProps['data-sb-field-path'] = fieldPath
+    }
+
+    if (objectId) {
+      editableProps['data-sb-object-id'] = objectId
+    }
   }
 
   return (

--- a/src/hooks/usePreviewMode.ts
+++ b/src/hooks/usePreviewMode.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+
+export default function usePreviewMode() {
+  const [isPreview, setIsPreview] = useState(false)
+  const location = useLocation()
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search)
+    const preview =
+      params.get('preview') === 'true' || import.meta.env.VITE_PREVIEW_MODE === 'true'
+
+    if (preview) {
+      document.body.classList.add('stackbit-preview')
+    }
+
+    setIsPreview(preview)
+  }, [location])
+
+  return isPreview
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,9 +1,10 @@
 
-import React from 'react';
+import React from 'react'
 import { Link } from 'react-router-dom';
-import { ArrowRight, Calendar, Users, Globe, BookOpen } from 'lucide-react';
+import { ArrowRight, Calendar, Users, Globe, BookOpen } from 'lucide-react'
+import EditableText from '@/components/editable/EditableText'
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
 import HomeSchema from '@/components/HomeSchema';
@@ -42,15 +43,20 @@ const Index = () => {
           >
             <div className="max-w-7xl mx-auto">
               <div className="text-center">
-                <h1 
-                  id="hero-heading"
+                <EditableText
+                  text="Civic and Citizenship Education Alliance"
+                  as="h1"
                   className="text-4xl md:text-6xl font-bold text-gray-900 mb-6"
-                >
-                  Civic and Citizenship Education Alliance
-                </h1>
-                <p className="text-xl md:text-2xl text-gray-600 mb-8 max-w-3xl mx-auto">
-                  Connecting educators, researchers, and policymakers worldwide to advance civic education and democratic participation.
-                </p>
+                  fieldPath="hero.title"
+                  objectId="home"
+                />
+                <EditableText
+                  text="Connecting educators, researchers, and policymakers worldwide to advance civic education and democratic participation."
+                  as="p"
+                  className="text-xl md:text-2xl text-gray-600 mb-8 max-w-3xl mx-auto"
+                  fieldPath="hero.subtitle"
+                  objectId="home"
+                />
                 <div className="flex flex-col sm:flex-row gap-4 justify-center">
                   <Button asChild size="lg" className="bg-blue-600 hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
                     <Link to="/membership" aria-describedby="join-description">
@@ -81,15 +87,21 @@ const Index = () => {
           >
             <div className="max-w-7xl mx-auto">
               <header className="text-center mb-16">
-                <h2 
+                <EditableText
+                  text="Empowering Global Civic Education"
+                  as="h2"
                   id="features-heading"
                   className="text-3xl md:text-4xl font-bold text-gray-900 mb-4"
-                >
-                  Empowering Global Civic Education
-                </h2>
-                <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-                  We bring together diverse perspectives and expertise to strengthen democratic institutions through education.
-                </p>
+                  fieldPath="features.title"
+                  objectId="home"
+                />
+                <EditableText
+                  text="We bring together diverse perspectives and expertise to strengthen democratic institutions through education."
+                  as="p"
+                  className="text-xl text-gray-600 max-w-2xl mx-auto"
+                  fieldPath="features.description"
+                  objectId="home"
+                />
               </header>
 
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8" role="list">
@@ -98,12 +110,22 @@ const Index = () => {
                     <div className="mx-auto w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4" aria-hidden="true">
                       <Calendar className="h-6 w-6 text-blue-600" />
                     </div>
-                    <CardTitle className="text-lg">Events & Conferences</CardTitle>
+                    <EditableText
+                      text="Events & Conferences"
+                      as="h3"
+                      className="text-lg"
+                      fieldPath="features.cards[0].title"
+                      objectId="home"
+                    />
                   </CardHeader>
                   <CardContent>
-                    <p className="text-gray-600">
-                      Join our global community at conferences, workshops, and networking events.
-                    </p>
+                    <EditableText
+                      text="Join our global community at conferences, workshops, and networking events."
+                      as="p"
+                      className="text-gray-600"
+                      fieldPath="features.cards[0].text"
+                      objectId="home"
+                    />
                   </CardContent>
                 </Card>
 
@@ -112,12 +134,22 @@ const Index = () => {
                     <div className="mx-auto w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mb-4" aria-hidden="true">
                       <BookOpen className="h-6 w-6 text-green-600" />
                     </div>
-                    <CardTitle className="text-lg">Research & Resources</CardTitle>
+                    <EditableText
+                      text="Research & Resources"
+                      as="h3"
+                      className="text-lg"
+                      fieldPath="features.cards[1].title"
+                      objectId="home"
+                    />
                   </CardHeader>
                   <CardContent>
-                    <p className="text-gray-600">
-                      Access cutting-edge research, publications, and educational materials.
-                    </p>
+                    <EditableText
+                      text="Access cutting-edge research, publications, and educational materials."
+                      as="p"
+                      className="text-gray-600"
+                      fieldPath="features.cards[1].text"
+                      objectId="home"
+                    />
                   </CardContent>
                 </Card>
 
@@ -126,12 +158,22 @@ const Index = () => {
                     <div className="mx-auto w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mb-4" aria-hidden="true">
                       <Users className="h-6 w-6 text-purple-600" />
                     </div>
-                    <CardTitle className="text-lg">Professional Network</CardTitle>
+                    <EditableText
+                      text="Professional Network"
+                      as="h3"
+                      className="text-lg"
+                      fieldPath="features.cards[2].title"
+                      objectId="home"
+                    />
                   </CardHeader>
                   <CardContent>
-                    <p className="text-gray-600">
-                      Connect with educators, researchers, and policymakers worldwide.
-                    </p>
+                    <EditableText
+                      text="Connect with educators, researchers, and policymakers worldwide."
+                      as="p"
+                      className="text-gray-600"
+                      fieldPath="features.cards[2].text"
+                      objectId="home"
+                    />
                   </CardContent>
                 </Card>
 
@@ -140,12 +182,22 @@ const Index = () => {
                     <div className="mx-auto w-12 h-12 bg-orange-100 rounded-lg flex items-center justify-center mb-4" aria-hidden="true">
                       <Globe className="h-6 w-6 text-orange-600" />
                     </div>
-                    <CardTitle className="text-lg">Global Impact</CardTitle>
+                    <EditableText
+                      text="Global Impact"
+                      as="h3"
+                      className="text-lg"
+                      fieldPath="features.cards[3].title"
+                      objectId="home"
+                    />
                   </CardHeader>
                   <CardContent>
-                    <p className="text-gray-600">
-                      Make a difference in civic education across diverse cultural contexts.
-                    </p>
+                    <EditableText
+                      text="Make a difference in civic education across diverse cultural contexts."
+                      as="p"
+                      className="text-gray-600"
+                      fieldPath="features.cards[3].text"
+                      objectId="home"
+                    />
                   </CardContent>
                 </Card>
               </div>
@@ -158,15 +210,21 @@ const Index = () => {
             aria-labelledby="cta-heading"
           >
             <div className="max-w-4xl mx-auto text-center">
-              <h2 
+              <EditableText
+                text="Ready to Join Our Community?"
+                as="h2"
                 id="cta-heading"
                 className="text-3xl md:text-4xl font-bold text-white mb-6"
-              >
-                Ready to Join Our Community?
-              </h2>
-              <p className="text-xl text-blue-50 mb-8">
-                Become part of a global network dedicated to strengthening democracy through education.
-              </p>
+                fieldPath="cta.title"
+                objectId="home"
+              />
+              <EditableText
+                text="Become part of a global network dedicated to strengthening democracy through education."
+                as="p"
+                className="text-xl text-blue-50 mb-8"
+                fieldPath="cta.subtitle"
+                objectId="home"
+              />
               <Button 
                 asChild 
                 size="lg" 
@@ -174,7 +232,12 @@ const Index = () => {
                 className="focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-blue-600"
               >
                 <Link to="/membership" aria-describedby="membership-cta-description">
-                  Explore Membership Options
+                  <EditableText
+                    text="Explore Membership Options"
+                    as="span"
+                    fieldPath="cta.button"
+                    objectId="home"
+                  />
                   <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
                 </Link>
               </Button>


### PR DESCRIPTION
## Summary
- add `usePreviewMode` hook to detect Netlify preview mode
- wrap footer and home page text in `<EditableText>` / `<EditableImage>` components
- only set Stackbit data attributes when preview is active

## Testing
- `npm run lint` *(fails: various eslint errors)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6855b0cc32ac83288a2e5509190b89a7