### PR TITLE
Add sitemap generator script and update build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && npm run generate:sitemap",
+    "generate:sitemap": "node scripts/generate-sitemap.js",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,3 +12,4 @@ Allow: /
 
 User-agent: *
 Allow: /
+Sitemap: https://ccea.org/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://ccea.org/</loc></url>
+  <url><loc>https://ccea.org/about</loc></url>
+  <url><loc>https://ccea.org/contact</loc></url>
+  <url><loc>https://ccea.org/articles</loc></url>
+  <url><loc>https://ccea.org/events</loc></url>
+  <url><loc>https://ccea.org/resources</loc></url>
+  <url><loc>https://ccea.org/members</loc></url>
+  <url><loc>https://ccea.org/team</loc></url>
+  <url><loc>https://ccea.org/membership</loc></url>
+  <url><loc>https://ccea.org/membership/individual</loc></url>
+  <url><loc>https://ccea.org/membership/institutional</loc></url>
+  <url><loc>https://ccea.org/governance</loc></url>
+  <url><loc>https://ccea.org/governance-charter</loc></url>
+  <url><loc>https://ccea.org/brand-guidelines</loc></url>
+  <url><loc>https://ccea.org/impressum</loc></url>
+  <url><loc>https://ccea.org/articles/global-perspectives-citizenship</loc></url>
+  <url><loc>https://ccea.org/articles/advancing-civic-education-digital-age</loc></url>
+  <url><loc>https://ccea.org/articles/transforming-civic-education-digital-age</loc></url>
+  <url><loc>https://ccea.org/events/annual-conference-2025</loc></url>
+  <url><loc>https://ccea.org/event-registration/annual-conference-2025</loc></url>
+  <url><loc>https://ccea.org/events/annual-ccea-conference-2025</loc></url>
+  <url><loc>https://ccea.org/event-registration/annual-ccea-conference-2025</loc></url>
+  <url><loc>https://ccea.org/resources/civic-education-toolkit</loc></url>
+  <url><loc>https://ccea.org/resources/civic-education-curriculum-framework</loc></url>
+  <url><loc>https://ccea.org/members/jane-smith</loc></url>
+  <url><loc>https://ccea.org/members/sample-university</loc></url>
+  <url><loc>https://ccea.org/team/maria-rodriguez</loc></url>
+  <url><loc>https://ccea.org/governance/code-of-conduct</loc></url>
+</urlset>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,93 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+async function readJSON(filePath) {
+  const data = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(data);
+}
+
+async function getSlugs(dir) {
+  const entries = await fs.readdir(dir);
+  const slugs = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue;
+    const fullPath = path.join(dir, entry);
+    const json = await readJSON(fullPath).catch(() => ({}));
+    const slug = json.slug || path.basename(entry, '.json');
+    slugs.push(slug);
+  }
+  return slugs;
+}
+
+async function main() {
+  const config = await readJSON(path.join('content', 'config.json'));
+  const baseUrl = config.site?.baseUrl?.replace(/\/$/, '') || '';
+
+  const staticRoutes = [
+    '/',
+    '/about',
+    '/contact',
+    '/articles',
+    '/events',
+    '/resources',
+    '/members',
+    '/team',
+    '/membership',
+    '/membership/individual',
+    '/membership/institutional',
+    '/governance',
+    '/governance-charter',
+    '/brand-guidelines',
+    '/impressum'
+  ];
+
+  const routes = [...staticRoutes];
+
+  const articleSlugs = await getSlugs(path.join('content', 'articles'));
+  routes.push(...articleSlugs.map((s) => `/articles/${s}`));
+
+  const eventSlugs = await getSlugs(path.join('content', 'events'));
+  routes.push(...eventSlugs.flatMap((s) => [`/events/${s}`, `/event-registration/${s}`]));
+
+  const resourceSlugs = await getSlugs(path.join('content', 'resources'));
+  routes.push(...resourceSlugs.map((s) => `/resources/${s}`));
+
+  const memberSlugs = await getSlugs(path.join('content', 'members'));
+  routes.push(...memberSlugs.map((s) => `/members/${s}`));
+
+  const teamSlugs = await getSlugs(path.join('content', 'team'));
+  routes.push(...teamSlugs.map((s) => `/team/${s}`));
+
+  const governanceSlugs = await getSlugs(path.join('content', 'governance'));
+  routes.push(...governanceSlugs.map((s) => `/governance/${s}`));
+
+  const xmlEntries = routes
+    .map((route) => `  <url><loc>${baseUrl}${route}</loc></url>`) 
+    .join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${xmlEntries}\n</urlset>\n`;
+
+  await fs.mkdir('public', { recursive: true });
+  await fs.writeFile(path.join('public', 'sitemap.xml'), xml);
+
+  // update robots.txt
+  const robotsPath = path.join('public', 'robots.txt');
+  let robots = '';
+  try {
+    robots = await fs.readFile(robotsPath, 'utf8');
+  } catch {
+    // ignore
+  }
+  const sitemapLine = `Sitemap: ${baseUrl}/sitemap.xml`;
+  if (!robots.includes('Sitemap:')) {
+    robots = robots.trim() + '\n' + sitemapLine + '\n';
+  } else if (!robots.includes(sitemapLine)) {
+    robots = robots.trim() + '\n' + sitemapLine + '\n';
+  }
+  await fs.writeFile(robotsPath, robots);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- generate a sitemap from content JSON files
- hook sitemap generation into the build command
- reference sitemap in `robots.txt`

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run generate:sitemap`

------
https://chatgpt.com/codex/tasks/task_e_6855b50b0ecc8328b9195f89fa946a4e